### PR TITLE
fix: #511 introduced custom basePath, however when custom basePath is…

### DIFF
--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -52,14 +52,16 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              {{- $contextPath := .Values.envs.config.SERVER_SERVLET_CONTEXT_PATH | default "" | printf "%s/" | urlParse }}
+              path: {{ get $contextPath "path" }}
               port: http
             initialDelaySeconds: 60
             periodSeconds: 30
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
-              path: /
+              {{- $contextPath := .Values.envs.config.SERVER_SERVLET_CONTEXT_PATH | default "" | printf "%s/" | urlParse }}
+              path: {{ get $contextPath "path" }}
               port: http
             initialDelaySeconds: 60
             periodSeconds: 30


### PR DESCRIPTION
… used than Helm chart livenessProbe and readinessProbe will fail because it will try to probe on the default path which does not exist anymore. With these changes it automatically picks up `SERVER_SERVLET_CONTEXT_PATH` from the myconfig.yaml and sets correct path for livenessProbe and readinessProbe

<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing applications:)
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "X" next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually(please, describe, when necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "X" next to an item, otherwise PR will fail)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [ ] My changes generate no new warnings(e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

Check out [Contributing](https://github.com/provectus/kafka-ui/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/provectus/kafka-ui/blob/master/CODE-OF-CONDUCT.md)